### PR TITLE
Prefer percentage based content width and em based positioning for more responsive media breaks

### DIFF
--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -775,8 +775,8 @@ td {
 }
 
 .article-content {
-    width: 800px;
-    margin: 35px auto;
+    width: 65%;
+    margin: 35px 15em;
 }
 
 footer .container {
@@ -795,8 +795,8 @@ footer .container {
 
 @media screen and (max-width: 1440px) and (min-width: 320px) {
     .article-content {
-        width: 600px;
-        margin: 35px auto;
+        width: 60%;
+        margin: 35px 15em;
     }
     footer .container {
         width: 650px;
@@ -816,7 +816,7 @@ footer .container {
         padding-bottom: 0;
     }
     .article-content {
-        width: 500px;
+        width: 57%;
     }
     footer .container {
         width: 550px;
@@ -836,7 +836,7 @@ footer .container {
 @media screen and (max-width: 992px) and (min-width: 320px) {
     .article-content,
     footer .container {
-        width: 520px;
+        width: 70%;
         margin-left: 233px;
     }
 


### PR DESCRIPTION
I noticed that there was often a lot of dead space in the content section of the docs. I was able to clear this up by setting the left margin to a fixed `em` width of the left menu so if the font size changes everything will scale uniformly.

The content body was using pixel based fixed values in its media queries. I converted these to percentage based values so the maximum amount of space is given to the content no matter what size the screen is.

Before:
<img width="1497" alt="screen shot 2017-07-23 at 11 07 58 pm" src="https://user-images.githubusercontent.com/159591/28506796-d9997810-6ffb-11e7-8e01-f315f47442e7.png">

After:
<img width="1497" alt="screen shot 2017-07-23 at 11 07 49 pm" src="https://user-images.githubusercontent.com/159591/28506802-df63f31a-6ffb-11e7-8976-6f788eeaf963.png">
