### PR TITLE
Sets position of article menu on /en/3.2/tutorial-base to fixed

### DIFF
--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -789,6 +789,9 @@ footer .container {
 @media screen and (max-width: 1600px) and (min-width: 320px) {
     .article-menu {
         right: 100px;
+        position: fixed;
+        background: white;
+        z-index: 1000;
     }
 
 }
@@ -842,6 +845,7 @@ footer .container {
 
     .article-menu {
         position: relative;
+        background: unset;
     }
 
 }


### PR DESCRIPTION
I noticed that at full width there is a secondary navigation for the tutorials. This quickly falls out of view and does not be come useful after 180px of scroll. So I set if fixed as long as the screen is full width. It will float with the scroll.

When the screen narrows the menu will return to its normal state and move to the top of the column.