### PR TITLE
Keep Tutorials from falling off the bottom of the nav.

### DIFF
--- a/app/views/templates/base.volt
+++ b/app/views/templates/base.volt
@@ -32,6 +32,7 @@
         <div class="row">
             <div class="col-md-2 sidebar hidden-xs">
                 {%- block sidebar -%}{%- endblock -%}
+                <div class="sidebar--spacer">&nbsp;</div>
             </div>
             <div class="m-t-md m-b-lg" id="articles">
                 <div class="article-content">

--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -650,18 +650,23 @@ td {
 .sidebar {
     position: fixed;
     z-index: 1;
-    top: 84px;
+    top: 7em;
     left: 0;
 
     overflow: auto;
 
     width: 200px;
-    height: 100vh;
+    height: 90vh;
 
     border-right: 1px solid #f0f2f1;
     background-color: #fff;
 
     font-size: 13px;
+}
+
+.sidebar--spacer {
+    width: 14em;
+    height: 10em;
 }
 
 .sidebar>ul,


### PR DESCRIPTION
###### Depends on https://github.com/phalcon/docs/pull/1145

As the top of the sidebar is shifted by padding the body content is slid off the bottom of the 100% container
the container must be the top height - top offset

Instead I am adding a spacer so the container hight can be bigger and fit on more screens
the spacer will absorb the overflow

The HTML element `.sidebar--space` effects is in phalcon/docs#1145