### PR TITLE
This router can handle cache busting static assets

### DIFF
--- a/.htrouter.php
+++ b/.htrouter.php
@@ -15,14 +15,43 @@
   +------------------------------------------------------------------------+
 */
 
-$uri = urldecode(
-    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
-);
+if(php_sapi_name() == "cli-server"){
+    // Set timezone
+    date_default_timezone_set("UTC");
 
-if ($uri !== '/' && file_exists(__DIR__ . '/public' . $uri)) {
-    return false;
+    $uri = urldecode(
+        parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+    );
+
+    $matches = [];
+    if(preg_match("/(.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif)$/", $uri, $matches)) {
+        $rewritten_uri = $matches[1] .".". $matches[2];
+        $rewritten_path = __DIR__ .'/public'. $rewritten_uri;
+        $pathinfo = pathinfo($rewritten_path);
+        switch($pathinfo['extension']) {
+            case 'css':
+                header("Content-Type: " . "text/css");
+                break;
+            case 'js':
+                header("Content-Type: " . "text/css");
+                break;
+            case 'png':
+            case 'jpg':
+            case 'jpeg':
+            case 'gif':
+                header("Content-Type: image/" . $pathinfo['extension']);
+                break;
+            default:
+                header("Content-Type: " . "text/plain");
+        }
+        return readfile($rewritten_path);
+    }
+
+    if ($uri !== '/' && file_exists(__DIR__ .'/public'. $uri)) {
+        return false;
+    }
+
+    $_GET['_url'] = $_SERVER['REQUEST_URI'];
+
+    require_once __DIR__ . '/public/index.php';
 }
-
-$_GET['_url'] = $_SERVER['REQUEST_URI'];
-
-require_once __DIR__ . '/public/index.php';

--- a/.htrouter.php
+++ b/.htrouter.php
@@ -15,7 +15,7 @@
   +------------------------------------------------------------------------+
 */
 
-if(php_sapi_name() == "cli-server"){
+if (php_sapi_name() == "cli-server") {
     // Set timezone
     date_default_timezone_set("UTC");
 
@@ -24,11 +24,11 @@ if(php_sapi_name() == "cli-server"){
     );
 
     $matches = [];
-    if(preg_match("/(.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif)$/", $uri, $matches)) {
-        $rewritten_uri = $matches[1] .".". $matches[2];
-        $rewritten_path = __DIR__ .'/public'. $rewritten_uri;
+    if (preg_match("/(.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif)$/", $uri, $matches)) {
+        $rewritten_uri = $matches[1] . "." . $matches[2];
+        $rewritten_path = __DIR__ . '/public' . $rewritten_uri;
         $pathinfo = pathinfo($rewritten_path);
-        switch($pathinfo['extension']) {
+        switch ($pathinfo['extension']) {
             case 'css':
                 header("Content-Type: " . "text/css");
                 break;
@@ -47,7 +47,7 @@ if(php_sapi_name() == "cli-server"){
         return readfile($rewritten_path);
     }
 
-    if ($uri !== '/' && file_exists(__DIR__ .'/public'. $uri)) {
+    if ($uri !== '/' && file_exists(__DIR__ . '/public' . $uri)) {
         return false;
     }
 


### PR DESCRIPTION
I got hung-up running this app locally because of url-rewrites. This enhances the local router to support these static asset path rewrites.

Interestingly enough I have a couple of other thoughts here.
- Router could be registered in `public/index.php` if it was wrapped in a `php_sapi_name() == "cli-server"` check. This would reduce a file from the project and allow execution context to simplify execution.
- Router Rewrites could be configurable allowing for an array of closures to be executed before transferring control to Phalcon