### PR TITLE
To keep users from having to touch the ./deploy source .env for DOCS_REPO env if set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_DEBUG=true
-; production, staging, development, testing
+# production, staging, development, testing
 APP_ENV=development
 APP_URL=http://docs.phalcon.ld
 APP_NAME="Documentation"
@@ -30,3 +30,5 @@ LOGGER_FORMAT='[%date%][%type%] %message%'
 LOGGER_LEVEL=debug
 
 GOOGLE_ANALYTICS=
+
+DOCS_REPO=https://github.com/phalcon/docs

--- a/deploy
+++ b/deploy
@@ -20,6 +20,10 @@ COMPOSER_BIN=$(command -v composer 2>/dev/null)
 
 DOCS_REPO=https://github.com/phalcon/docs
 
+if [ -f .env ]; then
+    source .env
+fi
+
 ST_OK=0
 ST_ERR=1
 ST_HLP=2


### PR DESCRIPTION
###### Relates to https://github.com/niden/blog-1/blob/master/data/posts/2017-07-29-helping-with-documentation.md

In preparation for a better guide to setting up docs locally I am trying to reduce the amount of files a new user has to touch. So this makes it so the user can setup the DOCS_REPO conditionally in the `.env` for the project instead of having to modify a bash file as well as the `.env` reducing the instructions by one step.

This checks to see if `.env` is set and if it is sources the file. A default value for DOCS_REPO is present prior to attempting to source the `.env` so there is a fallback.