### PR TITLE
These replacements for n` and n# are butchering a bunch of the api

### DIFF
--- a/app/controllers/BaseController.php
+++ b/app/controllers/BaseController.php
@@ -79,19 +79,11 @@ class BaseController extends PhController
         $data = str_replace(
             [
                 '[[language]]',
-                '[[version]]',
-                '0#', '1#', '2#', '3#', '4#',
-                '5#', '6#', '7#', '8#', '9#',
-                '0`', '1`', '2`', '3`', '4`',
-                '5`', '6`', '7`', '8`', '9`',
+                '[[version]]'
             ],
             [
                 $language,
-                $this->getVersion(),
-                '#', '#', '#', '#', '#',
-                '#', '#', '#', '#', '#',
-                '`', '`', '`', '`', '`',
-                '`', '`', '`', '`', '`',
+                $this->getVersion()
             ],
             $data
         );


### PR DESCRIPTION
###### Closes https://github.com/phalcon/docs/issues/1221

Before Parsedown numbers before # and numbers before` are being removed.

This is eating a bunch of valid numbers in the docs.

I don't see it being used anywhere either, please provide some feedback as to the purpose of these replacements before approving. I just don't see a current use but that doesn't mean it's not there.