### PR TITLE
fix navbar background repeating style

### DIFF
--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -518,7 +518,7 @@ pre tt {
     margin: 0;
 
     border: none;
-    background: url(../images/texture.png) repeat-x;
+    background: url(../images/texture.png);
     -webkit-box-shadow: 0 0 3px 0 rgba(37, 82, 95, 0.9);
     box-shadow: 0 0 3px 0 rgba(37, 82, 95, 0.9);
 }


### PR DESCRIPTION
the problem on the mobile version, because without repeating background image along the y axis, we can't see menu items