### PR TITLE
lighten edit pencil, tiny color tweeks

### DIFF
--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -3,8 +3,8 @@ html {
     height: 100%;
     padding: 0;
 
-    color: #333;
-    background-color: white;
+    color: #222;
+    background-color: #FAFBFB;
 
     font-family: "Lato", sans-serif;
     font-size: 14px;
@@ -13,12 +13,7 @@ html {
 
 body {
     position: relative;
-    /* font: 16px/24px Ubuntu, sans-serif; */
-
     min-width: 990px;
-
-    color: #000000;
-    background: #fff;
 }
 
 .article-page-wrap {
@@ -663,6 +658,7 @@ td {
 /** Sidebar */
 
 .sidebar {
+    padding-top: 1em;
     position: sticky;
     z-index: 1;
     float: left;
@@ -676,8 +672,10 @@ td {
 
     border-right: 1px solid #f0f2f1;
     background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px #bbb;
 
-    font-size: 13px;
+    font-size: 16px;
 }
 
 .sidebar--spacer {
@@ -731,31 +729,18 @@ td {
 
 /** article menu */
 
-/*.article-menu {
-    float: right;
-
-    width: 200px;
-    margin-left: 10px;
-    padding-top: 20px;
-    padding-left: 10px;
-
-    border-left: 1px solid #0a6278;
-
-    font-size: 13px;
-    /*background: #eeeeee;
-}*/
-
 .article-menu {
     position: absolute;
     right: 125px;
-
     width: 200px;
     padding-top: 20px;
+    padding-bottom: 16px;
     padding-left: 10px;
-
-    border-left: 1px solid #0a6278;
-
-    font-size: 13px;
+    margin-right: 4px;
+    border-left: 1px solid #f0f2f1;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px #bbb;
+    font-size: 16px;
 }
 
 .article-menu>ul {
@@ -806,7 +791,8 @@ footer .container {
 }
 
 .edit-pencil {
-    padding-left: .1em;
+    padding-left: .2em;
+    padding-bottom: .1em;
     max-height: .7em;
 }
 
@@ -828,7 +814,7 @@ footer .container {
     .article-menu {
         right: 100px;
         position: fixed;
-        background: white;
+        background-color: #FFFFFF;
         z-index: 1000;
     }
 }
@@ -1269,3 +1255,542 @@ footer .container {
 
 
 /*-------------------------/.MARGIN/PADDING-------------------------*/
+
+html {
+    font-size: 100%;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%
+}
+
+body {
+    margin: 0;
+    padding: 0
+}
+
+pre,
+code,
+address,
+caption,
+th,
+figcaption {
+    font-size: 1em;
+    font-weight: normal;
+    font-style: normal
+}
+
+fieldset,
+iframe,
+img {
+    border: none
+}
+
+caption,
+th {
+    text-align: left
+}
+
+table {
+    border-collapse: collapse;
+    border-spacing: 0
+}
+
+article,
+aside,
+footer,
+header,
+nav,
+main,
+section,
+summary,
+details,
+hgroup,
+figure,
+figcaption {
+    display: block
+}
+
+audio,
+canvas,
+video,
+progress {
+    display: inline-block;
+    vertical-align: baseline
+}
+
+button {
+    font: inherit;
+    vertical-align: middle
+}
+
+*,
+*:before,
+*:after {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+html,
+body {
+    height: 100%
+}
+
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, Verdana, sans-serif;
+    font-size: 18px;
+    line-height: 1.5;
+    color: #333;
+    font-weight: 300
+}
+
+body pre,
+body code {
+    font-family: Menlo, Consolas, Monaco, "Courier New", monospace, serif
+}
+
+p {
+    margin-bottom: 1.5em;
+}
+
+h1 {
+    margin-bottom: 0.5em;
+    font-size: 3em;
+    font-weight: 200;
+    line-height: 1;
+    padding-top: 1em;
+}
+
+h1.active+.main-nav {
+    border-top: 1px solid #333
+}
+
+h2 {
+    margin-bottom: 0.5em;
+    font-size: 2.5em;
+    font-weight: 200;
+    line-height: 1;
+    padding-top: 1em;
+}
+
+h3 {
+    margin-bottom: 0.5em;
+    font-size: 1.5em;
+    font-weight: 400;
+    line-height: 1
+}
+
+h4 {
+    margin-bottom: 0.5em;
+    font-size: 1.25em;
+    font-weight: 300;
+    line-height: 1.2
+}
+
+h5 {
+    margin-bottom: 0.5em;
+    font-size: 1.175em;
+    font-weight: 500;
+    line-height: 1.4
+}
+
+h6 {
+    margin-bottom: 0.5em;
+    font-size: 1em;
+    font-weight: 700;
+    line-height: 1.5
+}
+
+pre {
+    font-size: 14px;
+    line-height: 18px;
+    border-left: 3px #ef5138 solid;
+    margin: 0.5em;
+    margin-left: 10px;
+    margin-bottom: 1.5em;
+    padding: 0.5em;
+    padding-left: 1em;
+    overflow: scroll
+}
+
+p>code,
+li>code,
+dd>code,
+blockquote>code,
+td>code {
+    color: #000;
+    padding: 3px 8px;
+    font-size: 14px;
+    white-space: nowrap;
+    border: 1px solid #E5E5E5;
+    background-color: #f7f7f7
+}
+
+hr {
+    border: none;
+    border-top: 1px #f3f3f3 solid;
+    margin: 2em 0
+}
+
+hr:last-child {
+    display: none
+}
+
+details {
+    margin-bottom: 2em
+}
+
+details:first-child {
+    margin-top: 1.5em
+}
+
+cite {
+    display: block
+}
+
+cite:before {
+    content: "— "
+}
+
+article:first-of-type {
+    padding-bottom: 36px
+}
+
+article h2 {
+    padding-top: 1.1em
+}
+
+article h3 {
+    padding-top: 1em
+}
+
+article h4 {
+    padding-top: 1em;
+    border-bottom: 1px #f3f3f3 solid;
+    padding-bottom: 0.5em
+}
+
+article h5 {
+    margin-top: 1em
+}
+
+article header {
+    width: 100%;
+    display: inline-block;
+    padding-bottom: 3em
+}
+
+article header h1 {
+    padding-bottom: 0.125em
+}
+
+article header .byline {
+    float: left;
+    font-size: 14px;
+    margin-left: 3em
+}
+
+article header .byline img {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px #ccc solid;
+    position: absolute;
+    margin-right: 0.25em;
+    margin-top: -6px
+}
+
+article header .byline span {
+    padding-left: 42px
+}
+
+article header time {
+    float: left;
+    text-transform: uppercase;
+    font-size: 14px;
+    font-weight: 400;
+    color: #aaa
+}
+
+article header .tags {
+    display: block;
+    font-size: 12px;
+    font-weight: 400;
+    margin-top: 0
+}
+
+article:not(:first-of-type) {
+    border-top: 1px solid #e6e6e6;
+    padding: 36px 0
+}
+
+article blockquote {
+    border-left: 3px #c3c3c3 solid;
+    margin: 0.5em;
+    margin-left: 10px;
+    margin-bottom: 1.5em;
+    padding: 0.5em;
+    padding-left: 1em;
+    color: #333
+}
+
+article ul,
+article ol {
+    padding-left: 40px;
+    margin: 1em 0
+}
+
+article ul ul,
+article ul ol,
+article ol ul,
+article ol ol {
+    margin: 0
+}
+
+article ul {
+    list-style: disc
+}
+
+article ul ul {
+    list-style: circle
+}
+
+article ul ul ul {
+    list-style: square
+}
+
+article ol {
+    list-style: decimal
+}
+
+article dl {
+    margin: 2em 0 1em 0
+}
+
+article dl:after {
+    content: "";
+    display: table;
+    clear: both
+}
+
+article dl dt {
+    float: left;
+    clear: right;
+    margin-right: 1em;
+    display: block;
+    width: 28%;
+    text-align: right
+}
+
+article dl dd {
+    float: right;
+    width: 65%;
+    margin-bottom: 1em;
+    overflow: scroll
+}
+
+article dl dd {
+    padding-bottom: 1em;
+    border-bottom: 1px #f3f3f3 solid
+}
+
+article table {
+    width: auto;
+    min-width: 68%;
+    margin: 2em auto 3em auto;
+    border-collapse: separate;
+    border: 1px #e3e3e3 solid
+}
+
+article table th {
+    background: #fafafa;
+    font-weight: 700;
+    text-align: center
+}
+
+article table th,
+article table td {
+    width: 50%;
+    padding: 0.5em 1.5em;
+    border-bottom: 1px #f3f3f3 solid
+}
+
+article table th:not(:first-child),
+article table td:not(:first-child) {
+    border-left: 1px #f3f3f3 solid
+}
+
+article table tr:last-child td {
+    border-bottom: none
+}
+
+article details {
+    margin-top: 0;
+    cursor: pointer
+}
+
+article details summary {
+    padding-bottom: 0.5em;
+    outline: none;
+    margin-top: 0
+}
+
+article details summary:after {
+    content: "Expand";
+    text-transform: lowercase;
+    font-variant: small-caps;
+    border-bottom: 1px #ccc dashed
+}
+
+article details[open] summary:after {
+    content: "Collapse"
+}
+
+article details[open] *:not(summary) {
+    cursor: auto
+}
+
+article details.download {
+    margin-top: 0;
+    cursor: pointer
+}
+
+article details.download summary {
+    padding-bottom: 0.5em;
+    outline: none;
+    margin-top: 0
+}
+
+article details.download summary:after {
+    content: none;
+    text-transform: lowercase;
+    font-variant: small-caps;
+    border-bottom: 1px #ccc dashed
+}
+
+article details.download[open] summary:after {
+    content: none
+}
+
+article details.download[open] *:not(summary) {
+    cursor: auto
+}
+
+article>details {
+    margin-left: 40px
+}
+
+article .good pre,
+article pre.good {
+    background: #E6FFE5;
+    border-color: #C0FFBC
+}
+
+article .good pre:before,
+article pre.good:before {
+    content: "✅";
+    float: right
+}
+
+article .bad pre,
+article pre.bad {
+    background: #F9E2E4;
+    border-color: #F6B7BE
+}
+
+article .bad pre:before,
+article pre.bad:before {
+    content: "⛔️";
+    float: right
+}
+
+article footer {
+    margin: 4em 0 0 0;
+    padding: 1.5em 0 1em 0;
+    border-top: 1px #F3F3F3 solid
+}
+
+article footer:after {
+    content: "";
+    display: table;
+    clear: both
+}
+
+article footer nav [rel="prev"] {
+    width: 45%;
+    float: left;
+    text-align: left
+}
+
+article footer nav [rel="prev"]:before {
+    content: "← "
+}
+
+article footer nav [rel="next"] {
+    width: 45%;
+    float: right;
+    text-align: right
+}
+
+article footer nav [rel="next"]:after {
+    content: " →"
+}
+
+.title a:link,
+.title a:visited {
+    color: #333
+}
+
+.alert,
+.success,
+.info,
+.warning,
+.danger {
+    border-width: 1px;
+    border-style: solid;
+    padding: 0.5em;
+    margin: 0.5em 0 1.5em 0
+}
+
+.alert p:first-child,
+.success p:first-child,
+.info p:first-child,
+.warning p:first-child,
+.danger p:first-child {
+    margin-top: 0
+}
+
+.alert p:last-child,
+.success p:last-child,
+.info p:last-child,
+.warning p:last-child,
+.danger p:last-child {
+    margin-bottom: 0
+}
+
+.alert code,
+.success code,
+.info code,
+.warning code,
+.danger code {
+    border: none;
+    background: transparent;
+    padding: 0
+}
+
+code {
+    white-space: pre-line
+}
+
+pre code {
+    white-space: inherit
+}
+
+pre code .graphic {
+    font-size: 19px;
+    line-height: 0
+}
+
+pre code .commentary,
+pre code .graphic {
+    font-family: "Helvetica Neue", Helvetica, Arial, Verdana, sans-serif
+}

--- a/public/images/edit_pencil.svg
+++ b/public/images/edit_pencil.svg
@@ -1,24 +1,24 @@
 <svg width="45" height="47" viewBox="0 0 45 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <title>edit_pencil</title>
-<g id="Canvas" transform="translate(-206 282)">
+<g id="Canvas" transform="translate(-207 282)">
 <g id="edit_pencil">
 <g id="Polygon">
-<use xlink:href="#path0_fill" transform="matrix(0.962954 -0.269667 0.31362 0.949549 200.984 -247.671)"/>
+<use xlink:href="#path0_fill" transform="matrix(0.962954 -0.269667 0.31362 0.949549 201.984 -247.671)" fill="#445C6C"/>
 </g>
 <g id="Polygon">
-<use xlink:href="#path1_fill" transform="matrix(0.969418 -0.245417 0.289692 0.95712 204.925 -247.348)" fill="#FFFFFF"/>
+<use xlink:href="#path1_fill" transform="matrix(0.969418 -0.245417 0.289692 0.95712 205.925 -247.348)" fill="#FFFFFF"/>
 </g>
 <g id="Rectangle">
-<use xlink:href="#path2_fill" transform="matrix(0.707107 -0.707107 0.707107 0.707107 208.519 -250.079)"/>
+<use xlink:href="#path2_fill" transform="matrix(0.707107 -0.707107 0.707107 0.707107 209.519 -250.079)" fill="#445C6C"/>
 </g>
 <g id="Rectangle 4">
-<use xlink:href="#path3_fill" transform="matrix(0.707107 -0.707107 0.707107 0.707107 234.805 -276.364)"/>
+<use xlink:href="#path3_fill" transform="matrix(0.707107 -0.707107 0.707107 0.707107 235.805 -276.364)" fill="#445C6C"/>
 </g>
 <g id="Line">
-<use xlink:href="#path4_stroke" transform="matrix(0.707107 -0.707107 0.707107 0.707107 211 -246)" fill="#FFFFFF"/>
+<use xlink:href="#path4_stroke" transform="matrix(0.707107 -0.707107 0.707107 0.707107 212 -246)" fill="#FFFFFF"/>
 </g>
 <g id="Line">
-<use xlink:href="#path4_stroke" transform="matrix(0.707107 -0.707107 0.707107 0.707107 216 -241)" fill="#FFFFFF"/>
+<use xlink:href="#path4_stroke" transform="matrix(0.707107 -0.707107 0.707107 0.707107 217 -241)" fill="#FFFFFF"/>
 </g>
 </g>
 </g>


### PR DESCRIPTION
__this PR expands upon #52 `H45AN:Update-css-styles-for-better-readability`__

Per Discord conversation with @ninjapanzer and @H45AN (hasan) I lightened the `edit_pencil` color to match the updated styles. Additionally, I darkened the primary text color from `#333` to `#222` and made the main background color an extremely light shade of the gray/blue header color.

<img width="1165" alt="screen shot 2017-12-07 at 10 13 02 pm" src="https://user-images.githubusercontent.com/13909325/33805542-b2d44fde-dd88-11e7-8e8f-556f23bfd903.png">
