### PR TITLE
remove edit_pencil image from h1 and h2 tags

### DIFF
--- a/public/css/docs.css
+++ b/public/css/docs.css
@@ -168,6 +168,7 @@ h6 code {
 h1 {
     color: black;
 
+    display: inline-block;
     font-size: 28px;
 }
 
@@ -175,6 +176,7 @@ h2 {
     color: black;
     border-bottom: 1px solid #cccccc;
 
+    display: inline-block;
     font-size: 24px;
 }
 
@@ -806,8 +808,16 @@ footer .container {
 }
 
 .edit-pencil {
-    padding-left: .1em;
-    max-height: .7em;
+    padding-left: 1em;
+    padding-bottom: 10px;
+}
+
+.edit-pencil-h1 {
+    max-height: 2.5em;
+}
+
+.edit-pencil-h2 {
+    max-height: 2.2em;
 }
 
 .edit-pencil:hover{
@@ -895,11 +905,7 @@ footer .container {
     }
 }
 
-@media screen and (max-width: 354px) and (min-width: 320px) {
-    #edit-button-img {
-        height: 24px;
-    }
-}
+@media screen and (max-width: 354px) and (min-width: 320px) {}
 
 /*HELPERS*/
 

--- a/public/js/edit_button.js
+++ b/public/js/edit_button.js
@@ -1,20 +1,20 @@
 $(document).ready(function() {
   var link = $('.article-content-edit-link').attr('href')
   var text = $('.article-content-edit-link').html()
-  var editButton = '<a href=' + link + '><img src="/images/edit_pencil.svg" class="edit-pencil" alt="' + text + '"/></a>'
+  var editButton = '<a href=' + link + '><img src="/images/edit_pencil.svg" class="edit-pencil edit-pencil-h1" alt="' + text + '"/></a>'
   $( ".article-content h1" ).each(function() {
-    $( ".article-content h1" ).append(editButton)
+    $( ".article-content h1" ).after(editButton)
   })
 
   $(".article-content h2").each(function() {
     if(link.indexOf('crowdin') != -1){
-      var editButton = '<a href=' + link + '><img src="/images/edit_pencil.svg" class="edit-pencil" alt="' + text + '"/></a>'
+      var editButton = '<a href=' + link + '><img src="/images/edit_pencil.svg" class="edit-pencil edit-pencil-h2" alt="' + text + '"/></a>'
     } else {
       var h2id = $(this).text().toLowerCase()
       var elemId = h2id.replace(/[^\w 0-9]/ug, "").replace(/\s/g, "-")
       $(this).attr('id', elemId)
-      var editButton = '<a href=' + link + '/#' + elemId + '><img src="/images/edit_pencil.svg" class="edit-pencil" alt="Edit ' + $(this).text() + ' on GitHub"/></a>'
+      var editButton = '<a href=' + link + '/#' + elemId + '><img src="/images/edit_pencil.svg" class="edit-pencil edit-pencil-h2" alt="Edit ' + $(this).text() + ' on GitHub"/></a>'
     }
-    $(this).append(editButton)
+    $(this).after(editButton)
   })
 })


### PR DESCRIPTION
###### Remove `edit_pencil` image and link from H1 and H2 tags.

This should resolve the issue of the edit pencil showing up in the SEO and Google search results.

Converted the styles of the H1 and H2 elements to `display: inline-block` and changed our jQuery `append()` method to `after()`.

Tweaked the sizing of the image slightly to match heading styles.

<img width="1136" alt="screen shot 2017-12-21 at 8 33 10 pm" src="https://user-images.githubusercontent.com/13909325/34281829-5f5682a4-e68f-11e7-932b-66751989bfc7.png">
