### PR TITLE
Fixed including partials

### DIFF
--- a/app/views/error/show404.volt
+++ b/app/views/error/show404.volt
@@ -1,7 +1,7 @@
 {%- extends "templates/base.volt" -%}
 
 {%- block meta -%}
-    {%- include "include/noindex-meta.volt" with ['app_version': app_version] -%}
+    {%- include "include/noindex-meta.volt" -%}
 {%- endblock -%}
 
 {%- block sidebar -%}

--- a/app/views/error/show500.volt
+++ b/app/views/error/show500.volt
@@ -1,7 +1,7 @@
 {%- extends "templates/base.volt" -%}
 
 {%- block meta -%}
-    {%- include "include/noindex-meta.volt" with ['app_version': app_version] -%}
+    {%- include "include/noindex-meta.volt" -%}
 {%- endblock -%}
 
 {%- block sidebar -%}

--- a/app/views/index/article.volt
+++ b/app/views/index/article.volt
@@ -1,17 +1,9 @@
 {%- extends "templates/base.volt" -%}
 
 {%- block meta -%}
-    {%- include "include/meta.volt" with [
-        'url': url,
-        'language': language,
-        'name': name,
-        'description': description,
-        'keywords': keywords,
-        'description_long': description_long,
-        'app_version': app_version
-    ] -%}
+    {%- include "include/meta.volt" -%}
 {%- endblock -%}
 
 {%- block content -%}
-    {% include "inc/documentation-single.volt" with ['article': article] %}
+    {% include "inc/documentation-single.volt" %}
 {%- endblock -%}

--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -1,13 +1,5 @@
 {%- extends "templates/index.volt" -%}
 
 {%- block meta -%}
-    {%- include "include/meta.volt" with [
-        'url': url,
-        'language': language,
-        'name': name,
-        'description': description,
-        'keywords': keywords,
-        'description_long': description_long,
-        'app_version': app_version
-    ] -%}
+    {%- include "include/meta.volt" -%}
 {%- endblock -%}

--- a/app/views/index/search.volt
+++ b/app/views/index/search.volt
@@ -1,15 +1,7 @@
 {%- extends "templates/base.volt" -%}
 
 {%- block meta -%}
-    {%- include "include/meta.volt" with [
-        'url': url,
-        'name': name,
-        'language': language,
-        'description': description,
-        'keywords': keywords,
-        'description_long': description_long,
-        'app_version': app_version
-    ] -%}
+    {%- include "include/meta.volt" -%}
 {%- endblock -%}
 
 {%- block content -%}

--- a/app/views/templates/base.volt
+++ b/app/views/templates/base.volt
@@ -20,7 +20,7 @@
     {%- set keywords = config.path('app.keywords', 'php, phalcon, phalcon php, php framework, faster php framework') -%}
 
     {%- block meta -%}{%- endblock -%}
-    {%- include "include/icons.volt" with ['url': url] -%}
+    {%- include "include/icons.volt" -%}
     {%- include "include/analytics.volt" -%}
 
     {%- block head -%}

--- a/app/views/templates/index.volt
+++ b/app/views/templates/index.volt
@@ -24,8 +24,8 @@
 
     {%- block meta -%}{%- endblock -%}
 
-    {%- include "include/ie-support.volt" with ['app_version': app_version] -%}
-    {%- include "include/icons.volt" with ['url': url] -%}
+    {%- include "include/ie-support.volt" -%}
+    {%- include "include/icons.volt" -%}
     {%- include "include/analytics.volt" -%}
 
     {%- block head -%}
@@ -36,7 +36,7 @@
 </head>
 <body onclick="o2.allNavSlideUp()">
 {%- include 'inc/header.volt' -%}
-{%- include 'inc/advantages.volt' with ['url': url, 'language': language] -%}
+{%- include 'inc/advantages.volt' -%}
 {%- include 'inc/topics.volt' -%}
 {%- include 'inc/support.volt' -%}
 


### PR DESCRIPTION
**`include`** has a special behavior that will help us improve performance a bit when using Volt, if you specify the extension when including the file and it exists when the template is compiled, Volt can _inline the contents_ of the template in the parent template where it's included. Templates _aren't inlined_ if the **`include`** have variables passed with **`with`**