### PR TITLE
Update sidebar-topics.html

### DIFF
--- a/_includes/sidebar-topics.html
+++ b/_includes/sidebar-topics.html
@@ -7,7 +7,11 @@
         <ul style="display: none;">
             {% for item in topic.menu %}
             <li>
-                <a href="/{{ page.version }}/{{ page.language }}{{ item.url }}">
+                {% if item.external %}
+                <a href="{{ item.url }}">
+                {% else %}
+                <a href="/{{ page.version }}/{{ page.language }}{{ item.url }}">    
+                {% endif %}
                 <span>{{ item.text }}</span>
                 </a>
             </li>


### PR DESCRIPTION
External links are currently prefixed with docs url. For example: https://docs.phalconphp.com/4.0/enhttps://github.com/phalcon/cphalcon/blob/4.0.x/CHANGELOG.md

Added if statement to check if link is external