### PR TITLE
Lowercase url to fix canonical errors

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
     {% for lang in site.data.verlang.languages[page.version] %}
     {% if lang != page.language %}
     {%- assign new = '/' | append: lang | append: '/' -%}
-    <link rel="alternate" href="{{ site.url }}{{ page.url | replace: current, new | replace: '.html', '' }}" hreflang="{{ lang }}" />
+    <link rel="alternate" href="{{ site.url }}{{ page.url | replace: current, new | replace: '.html', '' | downcase }}" hreflang="{{ lang }}" />
     {% endif %}
     {% endfor %}
 
@@ -20,7 +20,7 @@
     <meta name="docsearch:language" content="{{ page.language | default: site.app.language }}">
     <meta name="docsearch:version" content="{{ page.version | default: site.app.version }}">
 
-    <link href="{{ page.url | replace:'index.html','' | prepend: site.url }}" rel="canonical">
+    <link href="{{ page.url | replace:'index.html','' | prepend: site.url | downcase }}" rel="canonical">
 
     <title>{{ site.app.title }}{% if page.title != "" %} - {{ page.title }}{% endif %}</title>
 


### PR DESCRIPTION
Urls must be lowercase to fix google errors
<img width="700" alt="Screenshot 2019-09-19 at 14 39 28" src="https://user-images.githubusercontent.com/7444246/65244641-51706180-daeb-11e9-931a-c98dee1295ef.png">
