### PR TITLE
Update sidebar-links.html

### DIFF
--- a/_includes/sidebar-links.html
+++ b/_includes/sidebar-links.html
@@ -19,7 +19,7 @@
                     </a>
                     {% else %}
                     <a class="documentation-nav-item__label"
-                       href="https://github.com/phalcon/docs/tree/4.0/en/{{ suffix }}.md">
+                       href="https://github.com/phalcon/docs/tree/{{ pageVersion }}/en/{{ suffix }}.md">
                         <strong>{{ homeStrings['edit_on_github'] }}</strong>
                     </a>
                     {% endif %}


### PR DESCRIPTION
The link to github had "4.0" hardcoded.  This changes it to use `{{ pageVersion }}`